### PR TITLE
refactor(playwright): playwright-tests.ymlの追加 Closes #8

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,10 +30,6 @@ jobs:
       (
         (github.event.action == 'assigned' && github.event.assignee.login == 'claude-bot') ||
         (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
-        (contains(github.event.pull_request.title, 'test') || 
-         contains(github.event.pull_request.title, 'cypress') ||
-         contains(github.event.pull_request.title, 'playwright') ||
-         contains(github.event.pull_request.title, 'robotframework'))
       )
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -13,7 +13,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       github.base_ref == 'develop' &&
-      (github.event.action == 'labeled' && github.event.label.name == 'playwright')
+      (github.event.action == 'labeled' && github.event.label.name == 'playwright-tests')
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +27,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -31,10 +31,13 @@ jobs:
           version: 8
 
       - name: Install dependencies
+        working-directory: ./playwright
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Browsers
+        working-directory: ./playwright
         run: pnpm exec playwright install --with-deps
 
       - name: Run Playwright tests
+        working-directory: ./playwright
         run: pnpm exec playwright test --reporter=dot

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -1,0 +1,39 @@
+name: Playwright Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    types: [labeled]
+
+jobs:
+  # PR作成時の自動テスト
+  playwright-test:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.base_ref == 'develop' &&
+      (github.event.action == 'labeled' && github.event.label.name == 'playwright')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: pnpm exec playwright test --reporter=dot

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./playwright
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Install Playwright Browsers
         working-directory: ./playwright

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
- ラベル付与時playwrightのテストが全実行されるようワークフローを追加する

## 概要

- このPRの目的 / 背景:PR作成時、ラベル付与でplaywrightのテストが全実行されるようにする
- このPRで解決すること: 変更を加えた際にplaywrightのテストが流れるかどうか検証することができる

## 変更タイプ

- [ ] 新規テストの追加
- [ ] 既存テストの修正/安定化（flaky対策）
- [ ] テストリファクタリング/メンテナンス
- [x] テスト基盤/CI/CD/インフラ変更
- [ ] ドキュメント更新
- [ ] その他（記載）:

## 影響範囲

- 対象フレームワーク: [x] Playwright [ ] Cypress [ ] Robot Framework
- 対象ブラウザ: [x] Chromium [x] WebKit [x] Firefox [ ] Chrome [ ] Edge
- 対象環境: [ ] ローカル [x] CI [ ] ステージング [ ] 本番相当
- データ/アカウント依存（固定ユーザー/固定データなど）: なし

## リスク・リリースノート

- 回帰リスク/影響範囲: 特にないはず
- ロールバック方法（テスト無効化/差分戻し等）: 特になし
- 破壊的変更の有無: なし

## レビュー観点

- 可読性（命名/分割/意図が読み取れるか）
- 再現性（固定データ/時間依存排除）
- 安定性（flaky回避の待ち・リトライ・期待値）
- 実行時間（過剰な待機の有無、並列実行耐性）
- 重複/DRY（共通化・PageObject/Builder/Facadeの活用）


